### PR TITLE
Added access_types register

### DIFF
--- a/lib/c99/nvm.rb
+++ b/lib/c99/nvm.rb
@@ -20,6 +20,46 @@ module C99
         reg.bits 15..0, :d
       end
 
+      # **Access Type Test Register**
+      #
+      # This register tests the various bit access types, such as write-one-to-clear,
+      # read-only, etc.
+      reg :access_types, 0x8, size: 32 do
+        # Test read-only access.
+        bit 31, :readonly, access: :ro
+        # Test read-write access.
+        bit 30, :readwrite, access: :rw
+        # Test read-clear access, where a read clears the value afterwards.
+        bit 29, :readclear, access: :rc
+        # Test read-set access, where a read sets the bit afterwards.
+        bit 28, :readset, access: :rs
+        # Test writable, clear-on-read access, etc...
+        bit 27, :writablereadclear, access: :wrc
+        bit 26, :writablereadset, access: :wrs
+        bit 25, :writeclear, access: :wc
+        bit 24, :writeset, access: :ws
+        bit 23, :writesetreadclear, access: :wsrc
+        bit 22, :writeclearreadset, access: :wcrs
+        bit 21, :write1toclear, access: :w1c
+        bit 20, :write1toset, access: :w1s
+        bit 19, :write1totoggle, access: :w1t
+        bit 18, :write0toclear, access: :w0c
+        bit 17, :write0toset, access: :w0s
+        bit 16, :write0totoggle, access: :w0t
+        bit 15, :write1tosetreadclear, access: :w1src
+        bit 14, :write1toclearreadset, access: :w1crs
+        bit 13, :write0tosetreadclear, access: :w0src
+        bit 12, :write0toclearreadset, access: :w0crs
+        bit 11, :writeonly, access: :wo
+        bit 10, :writeonlyclear, access: :woc
+        bit 9, :writeonlyreadzero, access: :worz
+        bit 8, :writeonlyset, access: :wos
+        bit 7, :writeonce, access: :w1
+        bit 6, :writeonlyonce, access: :wo1
+        bit 5, :readwritenocheck, access: :dc
+        bit 4, :readonlyclearafter, access: :rowz
+      end
+
       @blocks = [Block.new(0, self), Block.new(1, self), Block.new(2, self)]
     end
 


### PR DESCRIPTION
Added access_types register to enable testing of Origen core's ACCESS_CODES attributes.